### PR TITLE
fix slashes

### DIFF
--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -19,7 +19,7 @@
                     soundPath: '{{ asset($dir.'/sounds') }}',
                     dialog: {width: 900, modal: true, title: 'Select a file'},
                     resizable: false,
-                    onlyMimes: @json( unserialize(urldecode(request('mimes'))), JSON_UNESCAPED_SLASHES),
+                    onlyMimes: @json(unserialize(urldecode(request('mimes'))), JSON_UNESCAPED_SLASHES),
                     commandsOptions: {
                         getfile: {
                             multiple: {{ request('multiple') ? 'true' : 'false' }},

--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -19,7 +19,7 @@
                     soundPath: '{{ asset($dir.'/sounds') }}',
                     dialog: {width: 900, modal: true, title: 'Select a file'},
                     resizable: false,
-                    onlyMimes: @json(unserialize(urldecode(request('mimes')))),
+                    onlyMimes: @json( unserialize(urldecode(request('mimes'))), JSON_UNESCAPED_SLASHES),
                     commandsOptions: {
                         getfile: {
                             multiple: {{ request('multiple') ? 'true' : 'false' }},


### PR DESCRIPTION
Quote from https://github.com/Studio-42/elFinder/wiki/Client-configuration-options#onlyMimes

When I transfer data mimes as `"image/png"`
If JSON_UNESCAPED_SLASHES is not used, the resulting array will be `["image\/png"]` instead of `["image/png"]` resulting in failure to read any matching expansion files.