### PR TITLE
add missing config: root_options

### DIFF
--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -78,4 +78,16 @@ return [
 
     'options' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Root Options
+    |--------------------------------------------------------------------------
+    |
+    | These options are merged, together with every root by default.
+    | See https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options-2.1#root-options
+    |
+    */
+    'root_options' => [
+
+    ],
 ];


### PR DESCRIPTION
add config key `root_options` to pass options / configurations available here
https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options-2.1#root-options