### PR TITLE
add new options to enable client configuration from laravel config file

### DIFF
--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -78,4 +78,16 @@ return [
 
     'options' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Client Options
+    |--------------------------------------------------------------------------
+    |
+    | These options are converted into JSON and assigned on elfinder initialization.
+    | See https://github.com/Studio-42/elFinder/wiki/Client-configuration-options-2.1#contents
+    |
+    */
+    'client_options' => [
+
+    ],
 ];

--- a/resources/views/ckeditor4.blade.php
+++ b/resources/views/ckeditor4.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -23,11 +23,14 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
+                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                        {{ $key }}: @json($clientConfig),
+                    @endforeach
                     getFileCallback : function(file) {
                         window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
                         window.close();

--- a/resources/views/ckeditor4.blade.php
+++ b/resources/views/ckeditor4.blade.php
@@ -18,7 +18,7 @@
             $().ready(function() {
                 var funcNum = getUrlParam('CKEditorFuncNum');
 
-                var elf = $('#elfinder').elfinder({
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -28,14 +28,15 @@
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
-                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                        {{ $key }}: @json($clientConfig),
-                    @endforeach
                     getFileCallback : function(file) {
                         window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
                         window.close();
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
     </head>

--- a/resources/views/ckeditor4.php
+++ b/resources/views/ckeditor4.php
@@ -34,7 +34,7 @@
             $().ready(function() {
                 var funcNum = getUrlParam('CKEditorFuncNum');
 
-                var elf = $('#elfinder').elfinder({
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -48,7 +48,11 @@
                         window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
                         window.close();
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
     </head>

--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -15,11 +15,14 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ asset($dir.'/sounds') }}'
+                    soundPath: '{{ asset($dir.'/sounds') }}',
+                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                        {{ $key }}: @json($clientConfig),
+                    @endforeach
                 });
             });
         </script>

--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -10,7 +10,8 @@
             // Documentation for client options:
             // https://github.com/Studio-42/elFinder/wiki/Client-configuration-options
             $().ready(function() {
-                $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -19,11 +20,12 @@
                         _token: '{{ csrf_token() }}'
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ asset($dir.'/sounds') }}',
-                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                        {{ $key }}: @json($clientConfig),
-                    @endforeach
-                });
+                    soundPath: '{{ asset($dir.'/sounds') }}'
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig));
             });
         </script>
 @endsection

--- a/resources/views/elfinder.php
+++ b/resources/views/elfinder.php
@@ -26,7 +26,8 @@
             // Documentation for client options:
             // https://github.com/Studio-42/elFinder/wiki/Client-configuration-options
             $().ready(function() {
-                $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -36,7 +37,11 @@
                     },
                     url : '<?= route('elfinder.connector') ?>',  // connector URL
                     soundPath: '<?= asset($dir.'/sounds') ?>'
-                });
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig));
             });
         </script>
     </head>

--- a/resources/views/filepicker.blade.php
+++ b/resources/views/filepicker.blade.php
@@ -7,7 +7,8 @@
         
         <script type="text/javascript">
             $().ready(function () {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -52,7 +53,11 @@
                             oldSchool : false
                         }
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
     </head>

--- a/resources/views/filepicker.php
+++ b/resources/views/filepicker.php
@@ -24,7 +24,8 @@
 
         <script type="text/javascript">
             $().ready(function () {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -69,7 +70,11 @@
                             oldSchool : false
                         }
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
 

--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -12,7 +12,7 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
@@ -26,6 +26,9 @@
                             oncomplete: 'destroy'
                         }
                     },
+                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                        {{ $key }}: @json($clientConfig),
+                    @endforeach
                     getFileCallback: function (file) {
                         @if (request()->has('multiple') && request()->input('multiple') == 1)
                             window.parent.processSelectedMultipleFiles(file, '{{ $input_id  }}');

--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -7,7 +7,8 @@
 
         <script type="text/javascript">
             $().ready(function () {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -38,7 +39,11 @@
 
                         parent.jQuery.colorbox.close();
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
 

--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -27,9 +27,6 @@
                             oncomplete: 'destroy'
                         }
                     },
-                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                        {{ $key }}: @json($clientConfig),
-                    @endforeach
                     getFileCallback: function (file) {
                         @if (request()->has('multiple') && request()->input('multiple') == 1)
                             window.parent.processSelectedMultipleFiles(file, '{{ $input_id  }}');

--- a/resources/views/standalonepopup.php
+++ b/resources/views/standalonepopup.php
@@ -24,7 +24,8 @@
 
         <script type="text/javascript">
             $().ready(function () {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -45,7 +46,11 @@
                         window.parent.processSelectedFile(file.path, '<?= $input_id?>');
                         parent.jQuery.colorbox.close();
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
 

--- a/resources/views/tinymce.blade.php
+++ b/resources/views/tinymce.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -44,11 +44,14 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
+                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                        {{ $key }}: @json($clientConfig),
+                    @endforeach
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }

--- a/resources/views/tinymce.blade.php
+++ b/resources/views/tinymce.blade.php
@@ -39,7 +39,8 @@
             tinyMCEPopup.onInit.add(FileBrowserDialogue.init, FileBrowserDialogue);
 
             $().ready(function() {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -49,13 +50,14 @@
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
-                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                        {{ $key }}: @json($clientConfig),
-                    @endforeach
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
 

--- a/resources/views/tinymce.php
+++ b/resources/views/tinymce.php
@@ -55,7 +55,8 @@
             tinyMCEPopup.onInit.add(FileBrowserDialogue.init, FileBrowserDialogue);
 
             $().ready(function() {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -68,7 +69,11 @@
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
 

--- a/resources/views/tinymce4.blade.php
+++ b/resources/views/tinymce4.blade.php
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        
+
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
-        
+
         <!-- elFinder initialization (REQUIRED) -->
         <script type="text/javascript">
             var FileBrowserDialogue = {
@@ -26,11 +26,14 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
+                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                        {{ $key }}: @json($clientConfig),
+                    @endforeach
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }

--- a/resources/views/tinymce4.blade.php
+++ b/resources/views/tinymce4.blade.php
@@ -21,7 +21,8 @@
             }
 
             $().ready(function() {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     @if($locale)
                         lang: '{{ $locale }}', // locale
@@ -31,13 +32,14 @@
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ asset($dir.'/sounds') }}',
-                    @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                        {{ $key }}: @json($clientConfig),
-                    @endforeach
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = @json(config('elfinder.client_options'));
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
     </head>

--- a/resources/views/tinymce4.php
+++ b/resources/views/tinymce4.php
@@ -37,7 +37,8 @@
             }
 
             $().ready(function() {
-                var elf = $('#elfinder').elfinder({
+
+                var defaultElfConfig = {
                     // set your elFinder options here
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
@@ -50,7 +51,11 @@
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }
-                }).elfinder('instance');
+                };
+
+                var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+                var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
             });
         </script>
     </head>

--- a/resources/views/tinymce5.blade.php
+++ b/resources/views/tinymce5.blade.php
@@ -22,7 +22,8 @@
         };
 
         $().ready(function() {
-            var elf = $('#elfinder').elfinder({
+
+            var defaultElfConfig = {
                 // set your elFinder options here
                 @if($locale)
                     lang: '{{ $locale }}', // locale
@@ -32,13 +33,14 @@
                 },
                 url: '{{ route("elfinder.connector") }}',  // connector URL
                 soundPath: '{{ asset($dir.'/sounds') }}',
-                @foreach(config('elfinder.client_options') as $key => $clientConfig)
-                    {{ $key }}: @json($clientConfig),
-                @endforeach
                 getFileCallback: function(file) { // editor callback
                     FileBrowserDialogue.mySubmit(file); // pass selected file path to TinyMCE
                 }
-            }).elfinder('instance');
+            };
+
+            var overrideConfig = @json(config('elfinder.client_options'));
+
+            var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
         });
     </script>
 </head>

--- a/resources/views/tinymce5.blade.php
+++ b/resources/views/tinymce5.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    
+
     @include('vendor.elfinder.common_scripts')
     @include('vendor.elfinder.common_styles')
 
@@ -32,6 +32,9 @@
                 },
                 url: '{{ route("elfinder.connector") }}',  // connector URL
                 soundPath: '{{ asset($dir.'/sounds') }}',
+                @foreach(config('elfinder.client_options') as $key => $clientConfig)
+                    {{ $key }}: @json($clientConfig),
+                @endforeach
                 getFileCallback: function(file) { // editor callback
                     FileBrowserDialogue.mySubmit(file); // pass selected file path to TinyMCE
                 }

--- a/resources/views/tinymce5.php
+++ b/resources/views/tinymce5.php
@@ -38,7 +38,8 @@
         };
 
         $().ready(function() {
-            var elf = $('#elfinder').elfinder({
+
+            var defaultElfConfig = {
                 // set your elFinder options here
                 <?php if ($locale) { ?>
                 lang: '<?= $locale ?>', // locale
@@ -51,7 +52,11 @@
                 getFileCallback: function(file) { // editor callback
                     FileBrowserDialogue.mySubmit(file); // pass selected file path to TinyMCE
                 }
-            }).elfinder('instance');
+            };
+
+            var overrideConfig = <?= json_encode(config('elfinder.client_options')) ?>;
+
+            var elf = $('#elfinder').elfinder(Object.assign(defaultElfConfig, overrideConfig)).elfinder('instance');
         });
     </script>
 </head>


### PR DESCRIPTION
Instead of manually type the client configuration in the view, we can set the configuration directly from the laravel config file. List of configuration can be seen here
https://github.com/Studio-42/elFinder/wiki/Client-configuration-options-2.1#contents

--------------------------------------------------------------------------------
@tabacitu I'm not sure whether I should make this PR here or at https://github.com/barryvdh/laravel-elfinder . Just close this PR if you think I should make the PR at laravel-elfinder repo