### PR TITLE
fix #11 -  Route login not found by install laravel/ui

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,9 @@ Backpack admin interface for files and folder, using [barryvdh/laravel-elfinder]
 - publishes an elFinder config and view, for elFinder to play nice with Backpack;
 - adds a menu item to the sidebar;
 
+# for Laravel 8
+- install [laravel/ui](https://github.com/laravel/ui)
+
 ![https://backpackforlaravel.com/uploads/docs-4-0/media_library.png](https://backpackforlaravel.com/uploads/docs-4-0/media_library.png)
 
 


### PR DESCRIPTION
I feel that this step needed to be mentioned to users
because `laravel/ui` is no more installed by default 