### PR TITLE
fix Duplicate `Adding sidebar menu item` if installed multiple times

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -67,7 +67,7 @@ class Install extends Command
         switch (DIRECTORY_SEPARATOR) {
             case '/': // unix
                 $this->executeArtisanProcess('backpack:add-sidebar-content', [
-                    'code' => '<li class="nav-item"><a class="nav-link" href="{{ backpack_url(\'elfinder\') }}\"><i class="nav-icon la la-files-o"></i> <span>{{ trans(\'backpack::crud.file_manager\') }}</span></a></li>', ]);
+                    'code' => '<li class="nav-item"><a class="nav-link" href="{{ backpack_url(\'elfinder\') }}"><i class="nav-icon la la-files-o"></i> <span>{{ trans(\'backpack::crud.file_manager\') }}</span></a></li>', ]);
                 break;
             case '\\': // windows
                 $this->executeArtisanProcess('backpack:add-sidebar-content', [


### PR DESCRIPTION
# issue
In *windows*, I installed `Laravel-Backpack/FileManager` , then called this command:
```
 php artisan backpack:filemanager:install
```
then uploaded the script to a  *Linux*  server and again ran `php artisan backpack:filemanager:install`, and 

the item added again in the `sidebar`.. 

![image](https://user-images.githubusercontent.com/12745270/133128320-068e2c80-5d5c-4ff5-8003-553d643b6b2b.png)

##### i opened `` and compare them 
![image](https://user-images.githubusercontent.com/12745270/133129186-6345e9f5-6610-4eac-9152-3db32804c0e6.png)
and this is the result:
```diff
+ <li class="nav-item"><a class="nav-link" href="{{ backpack_url('elfinder') }}"><i class="nav-icon la la-files-o"></i> <span>{{ trans('backpack::crud.file_manager') }}</span></a></li>
- <li class="nav-item"><a class="nav-link" href="{{ backpack_url('elfinder') }}\"><i class="nav-icon la la-files-o"></i> <span>{{ trans('backpack::crud.file_manager') }}</span></a></li>
```