### PR TITLE
Laravel v9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "keywords": ["Laravel", "FileManager"],
     "require": {
         "backpack/crud": "^4.1|^5.0",
-        "barryvdh/laravel-elfinder": "^0.4.5"
+        "barryvdh/laravel-elfinder": "^0.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/laravel-backpack/filemanager",
     "keywords": ["Laravel", "FileManager"],
     "require": {
-        "backpack/crud": "^4.1|^5.0",
+        "backpack/crud": "^5.0",
         "barryvdh/laravel-elfinder": "^0.5.0"
     },
     "require-dev": {


### PR DESCRIPTION
After https://github.com/barryvdh/elfinder-flysystem-driver/pull/83, Barry did it 🙌
https://github.com/barryvdh/laravel-elfinder/releases/tag/v0.5.0

Backpack can now fully support Laravel v9