### PR TITLE
Update common_scripts.blade.php (jqueryui/1.10.4 to jqueryui/1.13.1)

### DIFF
--- a/resources/views/common_scripts.blade.php
+++ b/resources/views/common_scripts.blade.php
@@ -1,9 +1,9 @@
         <!-- jQuery and jQuery UI (REQUIRED) -->
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/themes/smoothness/jquery-ui.css" />
         @if (!isset ($jquery) || (isset($jquery) && $jquery == true))
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         @endif
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/jquery-ui.min.js"></script>
 
         <!-- elFinder JS (REQUIRED) -->
         <script src="{{ asset($dir.'/js/elfinder.min.js') }}"></script>


### PR DESCRIPTION
jqueryui/1.10.4 to jqueryui/1.13.1

Because some of designs were breaking which solved in this new version and elFinder itself used this new jQueryUI.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

?? Some of designs were breaking ( https://prnt.sc/OtGVbr3V1Gnc )

### AFTER - What is happening after this PR?

?? This type of breaking are solved ( https://prnt.sc/ynytaD8uXQSu )


## HOW

### How did you achieve that, in technical terms?

?? Just changed from *jqueryui/1.10.4* to *jqueryui/1.13.1*



### Is it a breaking change or non-breaking change?

?? Yes, it was a large issue, without that we could not close or reopen (pop up) the area ever again!


### How can we test the before & after?

?? Just change the version in file `\resources\views\common_scripts.blade.php`
