### PR TITLE
fix: replace `add-sidebar-content`

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -52,14 +52,14 @@ class Install extends Command
         // Adding sidebar menu item
         $this->progressBlock('Adding menu item');
         $this->executeArtisanProcess('backpack:add-menu-content', [
-            'code' => '<li class="nav-item"><a class="nav-link" href="{{ backpack_url(\'elfinder\') }}"><i class="nav-icon la la-files-o"></i> <span>{{ trans(\'backpack::crud.file_manager\') }}</span></a></li>',
+            'code' => '<x-backpack::menu-item title="trans(\'backpack::crud.file_manager\')" icon="la la-files-o" :link="backpack_url(\'elfinder\')" />',
         ]);
         $this->closeProgressBlock();
 
         // Done
         $url = Str::of(config('app.url'))->finish('/')->append('admin/elfinder');
         $this->infoBlock('Backpack FileManager installation complete.', 'done');
-        $this->note("Go to <fg=blue>$url</> to access your filemanager.");
+        $this->note('Go to <fg=blue>$url</> to access your filemanager.');
         $this->note('You may need to run <fg=blue>php artisan serve</> to serve your Laravel project.');
         $this->newLine();
     }

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -50,8 +50,8 @@ class Install extends Command
         $this->closeProgressBlock();
 
         // Adding sidebar menu item
-        $this->progressBlock('Adding sidebar menu item');
-        $this->executeArtisanProcess('backpack:add-sidebar-content', [
+        $this->progressBlock('Adding menu item');
+        $this->executeArtisanProcess('backpack:add-menu-content', [
             'code' => '<li class="nav-item"><a class="nav-link" href="{{ backpack_url(\'elfinder\') }}"><i class="nav-icon la la-files-o"></i> <span>{{ trans(\'backpack::crud.file_manager\') }}</span></a></li>',
         ]);
         $this->closeProgressBlock();

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -52,7 +52,7 @@ class Install extends Command
         // Adding sidebar menu item
         $this->progressBlock('Adding menu item');
         $this->executeArtisanProcess('backpack:add-menu-content', [
-            'code' => '<x-backpack::menu-item title="trans(\'backpack::crud.file_manager\')" icon="la la-files-o" :link="backpack_url(\'elfinder\')" />',
+            'code' => '<x-backpack::menu-item :title="trans(\'backpack::crud.file_manager\')" icon="la la-files-o" :link="backpack_url(\'elfinder\')" />',
         ]);
         $this->closeProgressBlock();
 


### PR DESCRIPTION
The `add-sidebar-content` command has been
replaced with `add-menu-content` in v6.


## WHY

### BEFORE - What was wrong? What was happening before this PR?

When installing FileManager with `composer`, the `backpack:add-sidebar-content` command causes an error to occur. This command has been replaced with `backpack:add-menu-content` in v6. 
[Error Link](https://imgur.com/a/Y2y14z3)

### AFTER - What is happening after this PR?

The command runs `backpack:add-menu-content` which functions as expected. 


## HOW

### How did you achieve that, in technical terms?

Replaced the two commands in the file `src/Console/Commands/Install.php`



### Is it a breaking change or non-breaking change?

Breaking


### How can we test the before & after?

Create a new version of Laravel 10
```
laravel new test-backpack6-filemanager
cd test-backpack6-filemanager
```
Then follow the Installation instructions.

> From your command line, require the package (this will also require barryvdh/laravel-elfinder):
> 
> ``` bash
> composer require backpack/filemanager
> ```
> 
> Then run the install process:
> 
> ```bash
> php artisan backpack:filemanager:install

```