### PR TITLE
Switch from using .zip to .tar.gz for basset archives

### DIFF
--- a/resources/views/common_scripts.blade.php
+++ b/resources/views/common_scripts.blade.php
@@ -4,12 +4,12 @@
         @endif
 
         {{-- jQuery UI and Smoothness theme --}}
-        @bassetArchive('https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.zip', 'jquery-ui-1.13.2')
+        @bassetArchive('https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.tar.gz', 'jquery-ui-1.13.2')
         @basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/themes/smoothness/jquery-ui.min.css')
         @basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/jquery-ui.min.js')
 
         {{-- elFinder JS (REQUIRED) --}}
-        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.zip', 'elfinder-2.1.61')
+        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.tar.gz', 'elfinder-2.1.61')
         @basset('elfinder-2.1.61/elFinder-2.1.61/js/elfinder.min.js')
 
         {{-- elFinder translation (OPTIONAL) --}}

--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -2,7 +2,7 @@
         <title>File Manager</title>
 
         {{-- elFinder CSS (REQUIRED) --}}
-        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.zip', 'elfinder-2.1.61')
+        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.tar.gz', 'elfinder-2.1.61')
         @basset('elfinder-2.1.61/elFinder-2.1.61/css/elfinder.min.css')
 
         {{-- elFinder Backpack Theme --}}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `@bassetArchive` calls where using the `.zip` format. This is not supported by default on all PHP installations (see also https://github.com/Laravel-Backpack/basset/pull/60).

### AFTER - What is happening after this PR?

Use the `.tar.gz` format, which was also available for these archives, and is enabled in PHP by default on all installations (see https://www.php.net/manual/en/phar.installation.php).


## HOW

### How did you achieve that, in technical terms?

Change the archive extensions.



### Is it a breaking change or non-breaking change?

No.


### How can we test the before & after?

Ensure assets still work fine.
