### PR TITLE
Set height to 100% on popup version of elfinder

### DIFF
--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -12,12 +12,13 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
                     soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
                     dialog: {width: 900, modal: true, title: 'Select a file'},
+                    height: '100%',
                     resizable: false,
                     onlyMimes: @json(unserialize(urldecode(request('mimes'))), JSON_UNESCAPED_SLASHES),
                     commandsOptions: {

--- a/resources/views/standalonepopup.php
+++ b/resources/views/standalonepopup.php
@@ -29,12 +29,13 @@
                     <?php if ($locale) { ?>
                         lang: '<?= $locale ?>', // locale
                     <?php } ?>
-                    customData: { 
+                    customData: {
                         _token: '<?= csrf_token() ?>'
                     },
                     url: '<?= route('elfinder.connector') ?>',  // connector URL
                     soundPath: '<?= asset($dir.'/sounds') ?>',
                     dialog: {width: 900, modal: true, title: 'Select a file'},
+                    height: '100%',
                     resizable: false,
                     commandsOptions: {
                         getfile: {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

On `browse` field, a popup containing the elFinder view is created. However the height of the appearing elFinder instance does not match the full height of the popup, causing weird whitespace to appear underneath it.

See also:
![afbeelding](https://github.com/Laravel-Backpack/FileManager/assets/45041769/6d8c5888-6a39-4cc6-8a75-52fa043b2300)

### AFTER - What is happening after this PR?

The elFinder instance takes up the entire space.


## HOW

### How did you achieve that, in technical terms?

Pass a height 100% argument.



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

Use on the demo; example above is from https://demo.backpackforlaravel.com/admin/pet-shop/owner/5/edit.
