### PR TITLE
Use local vendor directory as consistent source for elFinder assets

### DIFF
--- a/resources/views/ckeditor4.blade.php
+++ b/resources/views/ckeditor4.blade.php
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -23,11 +24,11 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                     getFileCallback : function(file) {
                         window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
                         window.close();

--- a/resources/views/common_scripts.blade.php
+++ b/resources/views/common_scripts.blade.php
@@ -1,21 +1,21 @@
-        {{-- jQuery (REQUIRED) --}}
-        @if (!isset ($jquery) || (isset($jquery) && $jquery == true))
-        @basset('https://unpkg.com/jquery@3.6.4/dist/jquery.min.js')
-        @endif
+{{-- jQuery (REQUIRED) --}}
+@if (!isset ($jquery) || (isset($jquery) && $jquery == true))
+@basset('https://unpkg.com/jquery@3.6.4/dist/jquery.min.js')
+@endif
 
-        {{-- jQuery UI and Smoothness theme --}}
-        @bassetArchive('https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.tar.gz', 'jquery-ui-1.13.2')
-        @basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/themes/smoothness/jquery-ui.min.css')
-        @basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/jquery-ui.min.js')
+{{-- jQuery UI and Smoothness theme --}}
+@bassetArchive('https://github.com/jquery/jquery-ui/archive/refs/tags/1.13.2.tar.gz', 'jquery-ui-1.13.2')
+@basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/themes/smoothness/jquery-ui.min.css')
+@basset('jquery-ui-1.13.2/jquery-ui-1.13.2/dist/jquery-ui.min.js')
 
-        {{-- elFinder JS (REQUIRED) --}}
-        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.tar.gz', 'elfinder-2.1.61')
-        @basset('elfinder-2.1.61/elFinder-2.1.61/js/elfinder.min.js')
+{{-- elFinder JS (REQUIRED) --}}
+@bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
+@basset('elfinder-vendor/js/elfinder.min.js')
 
-        {{-- elFinder translation (OPTIONAL) --}}
-        @if($locale)
-        @basset('https://cdnjs.cloudflare.com/ajax/libs/elfinder/2.1.61/js/i18n/elfinder.'.$locale.'.min.js')
-        @endif
+{{-- elFinder translation (OPTIONAL) --}}
+@if($locale)
+@basset('elfinder-vendor/js/i18n/elfinder.'.$locale.'.js')
+@endif
 
-        {{-- elFinder sounds --}}
-        @basset(base_path('vendor/studio-42/elfinder/sounds/rm.wav'))
+{{-- elFinder sounds --}}
+@basset('elfinder-vendor/sounds/rm.wav')

--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -1,9 +1,9 @@
-        <meta charset="utf-8">
-        <title>File Manager</title>
+<meta charset="utf-8">
+<title>File Manager</title>
 
-        {{-- elFinder CSS (REQUIRED) --}}
-        @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.tar.gz', 'elfinder-2.1.61')
-        @basset('elfinder-2.1.61/elFinder-2.1.61/css/elfinder.min.css')
+{{-- elFinder CSS (REQUIRED) --}}
+@bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
+@basset('elfinder-vendor/css/elfinder.min.css')
 
-        {{-- elFinder Backpack Theme --}}
-        @basset(base_path('vendor/backpack/filemanager/resources/assets/css/elfinder.backpack.theme.css'))
+{{-- elFinder Backpack Theme --}}
+@basset(base_path('vendor/backpack/filemanager/resources/assets/css/elfinder.backpack.theme.css'))

--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -1,6 +1,7 @@
 @extends(backpack_view('blank'))
 
 @section('after_scripts')
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -14,11 +15,11 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}'
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}'
                 });
             });
         </script>

--- a/resources/views/filepicker.blade.php
+++ b/resources/views/filepicker.blade.php
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
-        
+
         <script type="text/javascript">
             $().ready(function () {
                 var elf = $('#elfinder').elfinder({
@@ -16,7 +17,7 @@
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                     resizable: false,
                     ui: ['toolbar', 'path','stat'],
                     onlyMimes: [{{ $mimeTypes }}],

--- a/resources/views/standalonepopup.blade.php
+++ b/resources/views/standalonepopup.blade.php
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -12,11 +13,11 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                     dialog: {width: 900, modal: true, title: 'Select a file'},
                     resizable: false,
                     onlyMimes: @json(unserialize(urldecode(request('mimes'))), JSON_UNESCAPED_SLASHES),

--- a/resources/views/tinymce.blade.php
+++ b/resources/views/tinymce.blade.php
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
     <head>
-        
+
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
 
@@ -44,11 +45,11 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url : '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }

--- a/resources/views/tinymce4.blade.php
+++ b/resources/views/tinymce4.blade.php
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
-        
+
+        @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
         @include('vendor.elfinder.common_scripts')
         @include('vendor.elfinder.common_styles')
-        
+
         <!-- elFinder initialization (REQUIRED) -->
         <script type="text/javascript">
             var FileBrowserDialogue = {
@@ -26,11 +27,11 @@
                     @if($locale)
                         lang: '{{ $locale }}', // locale
                     @endif
-                    customData: { 
+                    customData: {
                         _token: '{{ csrf_token() }}'
                     },
                     url: '{{ route("elfinder.connector") }}',  // connector URL
-                    soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                    soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                     getFileCallback: function(file) { // editor callback
                         FileBrowserDialogue.mySubmit(file.url); // pass selected file path to TinyMCE
                     }

--- a/resources/views/tinymce5.blade.php
+++ b/resources/views/tinymce5.blade.php
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    
+
+    @bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')
     @include('vendor.elfinder.common_scripts')
     @include('vendor.elfinder.common_styles')
 
@@ -31,7 +32,7 @@
                     _token: '{{ csrf_token() }}'
                 },
                 url: '{{ route("elfinder.connector") }}',  // connector URL
-                soundPath: '{{ Basset::getUrl(base_path("vendor/studio-42/elfinder/sounds")) }}',
+                soundPath: '{{ Basset::getUrl("elfinder-vendor/sounds") }}',
                 getFileCallback: function(file) { // editor callback
                     FileBrowserDialogue.mySubmit(file); // pass selected file path to TinyMCE
                 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

ElFinder assets were collected from multiple places, i.e. the `vendor` directory, a GitHub archive and a CDN.

This should be no issue, but could cause inconsitencies as versions are not necessarily matching.

### AFTER - What is happening after this PR?

All ElFinder assets are retrieved from the vendor directory. This ensures consistency, removes external dependencies and allows updating/pinning the version by the user.


## HOW

### How did you achieve that, in technical terms?

Add a `@bassetDirectory(base_path('vendor/studio-42/elfinder/'), 'elfinder-vendor')` directive to have a "single source of truth" for elFinder assets. Note that the entire directory has to be copied, as some part of the elfinder script uses relative urls to fetch assets, which causes issues if only individual bassets are used.



### Is it a breaking change or non-breaking change?

No.


### How can we test the before & after?

Check the various implemented views to assert assets are loaded and correct.
