### PR TITLE
add inner css includes to basset

### DIFF
--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -4,6 +4,14 @@
 @bassetArchive('https://github.com/Studio-42/elFinder/archive/refs/tags/2.1.61.tar.gz', 'elfinder-2.1.61')
 @basset('elfinder-2.1.61/elFinder-2.1.61/css/elfinder.min.css')
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/css/theme.min.css')
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/images/loading.svg', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/icons/material.eot', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/icons/material.svg', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/images/icons-big.svg', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/images/icons-small.svg', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/icons/material.woff', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/icons/material.ttf', false)
+@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme/Material/icons/material.woff2', false)
 
 @bassetBlock('elfinderThemeSwitcherScript.js')
 <script type="text/javascript">


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/basset/issues/98

@promatik did well closing it there as it's not a basset issue, but user came back with more feedback https://github.com/Laravel-Backpack/basset/issues/98#issuecomment-1734951344 and made it clear where the problem was.

This is also the cause of the problem reported here: https://github.com/Laravel-Backpack/demo/issues/574

### AFTER - What is happening after this PR?

We add the files that the `.css` file load internally to basset to without outputting them as @promatik suggested.

