### PR TITLE
prevent mime types tampering

### DIFF
--- a/src/BackpackElfinderController.php
+++ b/src/BackpackElfinderController.php
@@ -11,6 +11,11 @@ class BackpackElfinderController extends \Barryvdh\Elfinder\ElfinderController
     {
         $mimes = request('mimes');
 
+        if (! isset($mimes)) {
+            Log::error('Someone attempted to tamper with mime types in elfinder popup. The attempt was blocked.');
+            abort(403, 'Unauthorized action.');
+        }
+
         try {
             $mimes = Crypt::decrypt(urldecode(request('mimes')));
         } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
@@ -18,7 +23,11 @@ class BackpackElfinderController extends \Barryvdh\Elfinder\ElfinderController
             abort(403, 'Unauthorized action.');
         }
 
-        request()->merge(['mimes' => urlencode(serialize($mimes))]);
+        if (! empty($mimes)) {
+            request()->merge(['mimes' => urlencode(serialize($mimes))]);
+        } else {
+            request()->merge(['mimes' => '']);
+        }
 
         return $this->app['view']
             ->make($this->package.'::standalonepopup')


### PR DESCRIPTION
this fixes a bug introduced in #58 where mime types were assumed to be always present. 

The intention was good, as that is the ultimate goal (end user unable to modify the mime types), but left a use case not covered. 

This now ensures mime-types are ALWAYS encrypted in the request, preventing users from removing the types from url. 