### PR TITLE
Simplify elFinder (dark) mode scripting

### DIFF
--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -34,8 +34,7 @@
 @endBassetBlock
 <span data-elfinder-light-theme-url="{{ Basset::getUrl('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme-gray.min.css') }}" style="display:none"></span>
 @bassetBlock('elfinderThemeSwitcherScript.js')
-<script type="text/javascript">
-document.addEventListener('DOMContentLoaded', function() {
+<script type="module">
     function getElfinderStyleSheet(main = true) {
     const regex = new RegExp(main ? `RobiNN1\/elFinder-Material-Theme@3.0.0\/Material\/css\/theme\.min\.css` : `RobiNN1\/elFinder-Material-Theme@3.0.0\/Material\/css\/theme-gray\.min\.css`);        const linkElements = document.querySelectorAll('link[rel="stylesheet"]');
         // Find the main elfinder stylesheet
@@ -68,7 +67,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     let colorMode = window.parent.colorMode?.result ?? window.colorMode?.result ?? false;
-   
+
     if(colorMode !== 'dark') {
         addElfinderLightStylesheet();
     }
@@ -87,23 +86,20 @@ document.addEventListener('DOMContentLoaded', function() {
             // in case we switched to dark mode, remove the ligth theme css
             if(scheme === 'dark') {
                 selectedLinkElement.parentNode.removeChild(selectedLinkElement);
-                return true; 
+                return true;
             }
             addElfinderLightStylesheet()
         });
     }
-
-});
 </script>
 @endBassetBlock
+
 @if($styleBodyElement ?? false)
-<script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-        // we dont want to style the body when elfinder is loaded as a component in a backpack view
-        // we pass true when loading elfinder inside an iframe to style the iframe body.
-        // use the topbar and footbar darker color as the background to ease transitions
-        document.getElementsByTagName('body')[0].style.background = '#061325';
-        document.getElementsByTagName('body')[0].style.opacity = 1;
-    });
+<script type="module">
+    // we dont want to style the body when elfinder is loaded as a component in a backpack view
+    // we pass true when loading elfinder inside an iframe to style the iframe body.
+    // use the topbar and footbar darker color as the background to ease transitions
+    document.getElementsByTagName('body')[0].style.background = '#061325';
+    document.getElementsByTagName('body')[0].style.opacity = 1;
 </script>
 @endif

--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -99,7 +99,7 @@
     // we dont want to style the body when elfinder is loaded as a component in a backpack view
     // we pass true when loading elfinder inside an iframe to style the iframe body.
     // use the topbar and footbar darker color as the background to ease transitions
-    document.getElementsByTagName('body')[0].style.background = '#061325';
-    document.getElementsByTagName('body')[0].style.opacity = 1;
+    document.body.style.background = '#061325';
+    document.body.style.opacity = 1;
 </script>
 @endif

--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -47,7 +47,8 @@
 @endBassetBlock
 
 @bassetBlock('elfinderThemeSwitcherScript.js')
-<script type="module">
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
     const getElfinderStyleLink = (name) => document.querySelector(`[data-stylesheet-name="elfinder-theme-${name}"]`);
 
     const setElfinderMode = (name) => {
@@ -66,6 +67,7 @@
         // Default to light mode
         setElfinderMode('light');
     }
+});
 </script>
 @endBassetBlock
 

--- a/resources/views/common_styles.blade.php
+++ b/resources/views/common_styles.blade.php
@@ -8,7 +8,20 @@
     'integrity' => 'sha384-e4Bm/JKXqLbEnnDNLZIbB0u9VBy3H9D+TNdLb22ybxTLsmtWgRhQ3/BKEgJ13zU2',
     'crossorigin' => 'anonymous',
 ])
-@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme.min.css')
+@php($elFinderLightTheme = 'https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme-gray.min.css')
+@basset($elFinderLightTheme, false)
+<link
+    rel="prefetch"
+    href="{{ Basset::getUrl($elFinderLightTheme) }}"
+    data-stylesheet-name="elfinder-theme-light"
+/>
+@php($elFinderDarkTheme = 'https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme.min.css')
+@basset($elFinderDarkTheme, false)
+<link
+    rel="prefetch"
+    href="{{ Basset::getUrl($elFinderDarkTheme) }}"
+    data-stylesheet-name="elfinder-theme-dark"
+/>
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/images/loading.svg', false)
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/font/material.eot', false)
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/font/material.svg', false)
@@ -17,7 +30,7 @@
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/font/material.woff', false)
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/font/material.ttf', false)
 @basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/font/material.woff2', false)
-@basset('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme-gray.min.css', false)
+
 @bassetBlock('elfinderCommonStyles.css')
 <style>
     .elfinder .elfinder-toolbar .elfinder-button,
@@ -32,64 +45,26 @@
     }
 </style>
 @endBassetBlock
-<span data-elfinder-light-theme-url="{{ Basset::getUrl('https://cdn.jsdelivr.net/gh/RobiNN1/elFinder-Material-Theme@3.0.0/Material/css/theme-gray.min.css') }}" style="display:none"></span>
+
 @bassetBlock('elfinderThemeSwitcherScript.js')
 <script type="module">
-    function getElfinderStyleSheet(main = true) {
-    const regex = new RegExp(main ? `RobiNN1\/elFinder-Material-Theme@3.0.0\/Material\/css\/theme\.min\.css` : `RobiNN1\/elFinder-Material-Theme@3.0.0\/Material\/css\/theme-gray\.min\.css`);        const linkElements = document.querySelectorAll('link[rel="stylesheet"]');
-        // Find the main elfinder stylesheet
-        let selectedLinkElement;
-        for (const linkElement of linkElements) {
-            if (regex.test(linkElement.href)) {
-                selectedLinkElement = linkElement;
-                break;
-            }
-        }
-        return selectedLinkElement;
+    const getElfinderStyleLink = (name) => document.querySelector(`[data-stylesheet-name="elfinder-theme-${name}"]`);
+
+    const setElfinderMode = (name) => {
+        const darkModeStyleLink = getElfinderStyleLink('dark');
+        darkModeStyleLink.rel = name === 'dark' ? 'stylesheet' : 'prefetch';
+        const lightModeStyleLink = getElfinderStyleLink('light');
+        lightModeStyleLink.rel = name === 'light' ? 'stylesheet' : 'prefetch';
     }
 
-    function addElfinderLightStylesheet() {
-        let lightThemeEl = document.querySelector('[data-elfinder-light-theme-url]');
-        if (!lightThemeEl) return;
-        let lightThemeUrl = lightThemeEl.getAttribute('data-elfinder-light-theme-url');
-        if (!lightThemeUrl) return;
-
-        let mainStyleSheet = getElfinderStyleSheet();
-        let lightStyleSheet = getElfinderStyleSheet(false);
-        // if found append the light mode css to the main theme stylesheet
-        if (mainStyleSheet && ! lightStyleSheet) {
-            let themeLight = document.createElement('link');
-            themeLight.href = lightThemeUrl;
-            themeLight.rel = 'stylesheet';
-            themeLight.type = 'text/css';
-            mainStyleSheet.insertAdjacentElement('afterend', themeLight);
-        }
-    }
-
-    let colorMode = window.parent.colorMode?.result ?? window.colorMode?.result ?? false;
-
-    if(colorMode !== 'dark') {
-        addElfinderLightStylesheet();
-    }
-
-    // register a color mode change event so that we remove
-    // the light stylesheet when the color mode change
-    if(colorMode) {
-        let colorModeClass = window.parent.colorMode ?? window.colorMode;
-        colorModeClass.onChange(function(scheme) {
-            let getMainStylesheet = scheme === 'dark' ? false : true;
-            let selectedLinkElement = getElfinderStyleSheet(getMainStylesheet);
-
-            if (! selectedLinkElement) {
-                return true;
-            }
-            // in case we switched to dark mode, remove the ligth theme css
-            if(scheme === 'dark') {
-                selectedLinkElement.parentNode.removeChild(selectedLinkElement);
-                return true;
-            }
-            addElfinderLightStylesheet()
-        });
+    const colorModeClass = window.parent.colorMode ?? window.colorMode ?? null;
+    if (colorModeClass) {
+        // Set mode based on configuration and watch for changes
+        setElfinderMode(colorModeClass.result);
+        colorModeClass.onChange((scheme) => setElfinderMode(scheme));
+    } else {
+        // Default to light mode
+        setElfinderMode('light');
     }
 </script>
 @endBassetBlock


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The previous scripting was both somewhat computationally heavy (leveraging lots of loops and regexes) and hard to understand.

### AFTER - What is happening after this PR?

In the new script, a simple strategy is applied:
1. there are two `link` elements, one for light mode and one for dark mode stylesheets
2. both are initialized with `rel=prefetch`, so that the corresponding asset may be fetched if browser supports this directive and prioritizes it at some point, but neither of the stylesheets are 'active'
3. after detecting current mode and on any subsequent change, the relevant stylesheet is 'activated' by setting `rel=stylesheet`, while disabling the other by using `rel=prefetch`

Also some related code has been slightly cleaned up.

## HOW

### How did you achieve that, in technical terms?

Refactor



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

Behavior should remain practically identical
