### PR TITLE
Allow barryvdh/laravel-elfinder ^0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "keywords": ["Laravel", "FileManager"],
     "require": {
         "backpack/crud": "^7.0",
-        "barryvdh/laravel-elfinder": "^0.5.2"
+        "barryvdh/laravel-elfinder": "^0.5.2|^0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0",


### PR DESCRIPTION
The next release of this package will be 0.6.0 (see https://github.com/barryvdh/laravel-elfinder/pull/320#issuecomment-4142963877 and https://github.com/barryvdh/laravel-elfinder/commit/357fbae9d110bb80d4b57165e9ea7f455b43a3be). This will likely be tagged once https://github.com/barryvdh/laravel-elfinder/pull/338 is merged. Consequently, the new release will allow intervention/image v4 (see also https://github.com/barryvdh/elfinder-flysystem-driver/pull/103).

To ensure all these (nested) updates are allowed, we allow the new version here.

*Edit:* release has just landed with https://github.com/barryvdh/laravel-elfinder/releases/tag/v0.6.0.