### PR TITLE
Fix locale detection and add $dir for backward compatibility

### DIFF
--- a/resources/views/common_scripts.blade.php
+++ b/resources/views/common_scripts.blade.php
@@ -15,10 +15,5 @@
 {{-- elFinder JS (REQUIRED) --}}
 @basset(base_path('vendor/studio-42/elfinder/js/elfinder.min.js'))
 
-{{-- elFinder translation (OPTIONAL) --}}
-@if($locale)
-	@basset('bp-elfinder-i18n-'.$locale)
-@endif
-
 {{-- elFinder sounds --}}
 @basset(base_path('vendor/studio-42/elfinder/sounds/rm.wav'))

--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -26,6 +26,12 @@
     <script type="text/javascript" charset="utf-8">
         // Documentation for client options:
         // https://github.com/Studio-42/elFinder/wiki/Client-configuration-options
+        
+        // elFinder does not fully support jQuery UI 1.13+ yet, so we need to add this workaround.
+        if (typeof $.fn.buttonset !== 'function' && typeof $.fn.controlgroup === 'function') {
+            $.fn.buttonset = $.fn.controlgroup;
+        }
+
         $(document).ready(function() {
             $('#elfinder').elfinder({
                 // set your elFinder options here

--- a/src/BackpackElfinderController.php
+++ b/src/BackpackElfinderController.php
@@ -49,14 +49,15 @@ class BackpackElfinderController extends \Barryvdh\Elfinder\ElfinderController
 
     protected function getViewVars()
     {
+        $dir = 'packages/barryvdh/' . $this->package;
         $locale = str_replace('-', '_', $this->app->config->get('app.locale'));
 
-        if (! array_key_exists('bp-elfinder-i18n-'.$locale, Basset::getNamedAssets())) {
+        if (! file_exists(base_path("vendor/studio-42/elfinder/js/i18n/elfinder.{$locale}.js"))) {
             $locale = false;
         }
 
         $csrf = true;
 
-        return compact('locale', 'csrf');
+        return compact('dir', 'locale', 'csrf');
     }
 }

--- a/src/BackpackElfinderController.php
+++ b/src/BackpackElfinderController.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\FileManager;
 
-use Backpack\Basset\Facades\Basset;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 
@@ -49,7 +48,7 @@ class BackpackElfinderController extends \Barryvdh\Elfinder\ElfinderController
 
     protected function getViewVars()
     {
-        $dir = 'packages/barryvdh/' . $this->package;
+        $dir = 'packages/barryvdh/'.$this->package;
         $locale = str_replace('-', '_', $this->app->config->get('app.locale'));
 
         if (! file_exists(base_path("vendor/studio-42/elfinder/js/i18n/elfinder.{$locale}.js"))) {


### PR DESCRIPTION
This fixes the locale detection of `getViewVars()` and adds the parent `$dir` variable for backwards compatibility. 


